### PR TITLE
削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   skip_before_action :require_authentication, only: [ :index ] # 投稿一覧画面は誰でも見れるようにする
-  before_action :ensure_current_user, only: [ :edit, :update ]
+  before_action :ensure_current_user, only: [ :edit, :update, :destroy ]
 
   def index
     @posts = Post.all.order(created_at: :desc)
@@ -35,6 +35,11 @@ class PostsController < ApplicationController
     else
       render :edit, status: unprocessable_entity
     end
+  end
+
+  def destroy
+    @post.destroy!
+    redirect_to root_path, notice: "投稿を削除しました"
   end
 
   def watched

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
   <% if @post.user_id == current_user.id %>
     <div class="mt-6 flex gap-4">
       <%= link_to "編集する", edit_post_path(@post), class: "bg-yellow-500 text-white px-4 py-2 rounded-md hover: bg-yellow-600 transition-colors" %>
-      <%= button_to "削除する", posts_path(@post), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 text-white px-4 py-2 rounded-md hover:bg-red-600 transition-colors" %>
+      <%= button_to "削除する", root_path(@post), method: :delete, data: { turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 text-white px-4 py-2 rounded-md hover:bg-red-600 transition-colors" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
fixes #41

## 概要
作品の削除機能を実装しました。

## 変更点
 - ensure_correct_user メソッドを before_action として追加し、所有者以外の削除を制限

## 動作確認
 - 別アカウントから作品の詳細画面へ遷移したとき削除ボタンが表示されない
 - ユーザーが自分で投稿した作品を削除できる
 - 削除する際「本当に削除しますか？」というメッセージが表示される
 - 削除後「投稿を削除しました」と表示される